### PR TITLE
replace Greasyfork with MHCT info

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -32,7 +32,7 @@ export default function Home() {
           </a>
 
           <a
-            href="https://greasyfork.org/en/scripts/by-site/mousehuntgame.com"
+            href="https://m-h-c-t.github.io/mh-info/"
             className={styles.card}
           >
             <h2>Userscripts &rarr;</h2>


### PR DESCRIPTION
theres undesirable scripts when you direct link to GF. tho MHCT is unfleshed out, we should head over and flesh it out.